### PR TITLE
Add string#email validator

### DIFF
--- a/src/validators/string-validator.test.ts
+++ b/src/validators/string-validator.test.ts
@@ -19,11 +19,13 @@ describe('jointz#string', () => {
 
   it('validates patterns correctly', () => {
     expect(jointz.string().pattern(/^[abc]{3,4}$/).validate('abc', []))
-      .to.be.an('array').with.length(0);
+      .to.deep.eq([]);
     expect(jointz.string().pattern(/^[abc]{3,4}$/).validate('abcd', []))
-      .to.be.an('array').with.length(1);
+      .to.deep.eq([ { message: 'did not match pattern', path: [], value: 'abcd' } ]);
     expect(jointz.string().pattern(/^[abc]{3,4}$/).validate('abca', []))
-      .to.be.an('array').with.length(0);
+      .to.deep.eq([]);
+    expect(jointz.string().pattern(/^[abc]{3,4}$/).validate('abcdab', []))
+      .to.deep.eq([ { message: 'did not match pattern', path: [], value: 'abcdab' } ]);
   });
 
   it('validates uuids correctly', () => {
@@ -55,8 +57,17 @@ describe('jointz#string', () => {
       .to.be.an('array').with.length(1);
     expect(jointz.string().pattern(/^[abc]{3,4}$/).maxLength(3).validate('abcd', []))
       .to.be.an('array').with.length(2);
-    expect(jointz.string().pattern(/^[abc]{3,4}$/).minLength(4).validate('abc', []))
-      .to.be.an('array').with.length(1);
+  });
+
+  it('validates email propertly', () => {
+    expect(jointz.string().email().validate('this is not an email', []))
+      .to.deep.eq([ { message: 'must be a valid email', path: [], value: 'this is not an email' } ]);
+    expect(jointz.string().email().validate('email1@email.com', []))
+      .to.deep.eq([]);
+    expect(jointz.string().email().validate('super@email.test', []))
+      .to.deep.eq([]);
+    expect(jointz.string().email().validate('complex+email.a@dom.dom.dom', []))
+      .to.deep.eq([]);
   });
 
   it('throws with invalid minLength', () => {

--- a/src/validators/string-validator.ts
+++ b/src/validators/string-validator.ts
@@ -2,6 +2,10 @@ import { ValidationError, ValidationErrorPath, Validator } from '../interfaces';
 
 const ALPHANUMERIC_REGEX = /^[a-zA-Z0-9]*$/;
 const UUID_REGEX = /^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/;
+/**
+ * Based on https://stackoverflow.com/a/46181/1126380
+ */
+const EMAIL_REGEX = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/i;
 
 interface StringValidatorOptions {
   readonly pattern?: RegExp;
@@ -66,6 +70,10 @@ export default class StringValidator extends Validator<string> {
     return new StringValidator({ ...this.options, pattern: UUID_REGEX });
   }
 
+  public email(): StringValidator {
+    return this.pattern(EMAIL_REGEX);
+  }
+
   public validate(value: any, path: ValidationErrorPath = []): ValidationError[] {
     const { pattern, minLength, maxLength } = this.options;
 
@@ -76,14 +84,16 @@ export default class StringValidator extends Validator<string> {
     const errors: ValidationError[] = [];
 
     if (pattern && !pattern.test(value)) {
+      const message = 
+          pattern === ALPHANUMERIC_REGEX
+        ? 'must be alphanumeric'
+        : pattern === UUID_REGEX
+        ? 'must be a uuid' 
+        : pattern === EMAIL_REGEX
+        ? 'must be a valid email'
+        : 'did not match pattern'
       errors.push({
-        message: pattern === ALPHANUMERIC_REGEX ?
-          'must be alphanumeric' :
-          (
-            pattern === UUID_REGEX ?
-              'must be a uuid' :
-              'did not match pattern'
-          ),
+        message,
         path,
         value
       });


### PR DESCRIPTION
New validator that verify that a given string is a valid email,
based on the regexp defined in
https://stackoverflow.com/a/46181/1126380.

This is not a perfect solution, but it works well in the majority of the
cases.